### PR TITLE
DX-22 update GHA runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build_test:
     name: Build Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     steps:
@@ -42,7 +42,7 @@ jobs:
         working-directory: .
   build_dev:
     name: Build Dev
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: dev
     steps:
@@ -71,7 +71,7 @@ jobs:
   test:
     name: Test
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     steps:
@@ -97,7 +97,7 @@ jobs:
   credo_and_dialyxir:
     name: Credo + Dialyxir
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     steps:
@@ -131,7 +131,7 @@ jobs:
   audit:
     name: Audit
     needs: build_dev
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: dev
     steps:
@@ -167,7 +167,7 @@ jobs:
       - test
       - credo_and_dialyxir
       - audit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir


### PR DESCRIPTION
GitHub is retiring ubuntu-20.04 runners, so we need to replace them.